### PR TITLE
require node 16 due to adapter core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "type": "git",
     "url": "https://github.com/MiSchroe/ioBroker.klf200"
   },
+  "engines": {
+    "node": ">= 16"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.4",
     "klf-200-api": "^3.1.3",


### PR DESCRIPTION
adapter-core 3.x.x is known to fail when installing at node 14 or earlier due to npm not installing peer dependencies. So this adapter requires node 16 or newer.